### PR TITLE
Fix libtcc build

### DIFF
--- a/lib/tcc/api.js
+++ b/lib/tcc/api.js
@@ -94,7 +94,7 @@ async function build (C = 'gcc', CC = 'g++') {
     const status = new Int32Array(2)
     exec('./configure', ['--extra-cflags=-mstackrealign -fPIC'], status)
     assert(status[0] === 0)
-    exec('make', ['clean', 'libtcc.a'], status)
+    exec('make', [`CC=${C}`, 'clean', 'libtcc.a'], status)
     assert(status[0] === 0)
     assert(chdir('../../') === 0)
   }


### PR DESCRIPTION
currently we use C variable for c compiler and CC for c++ compiler. but this does not seem to be standard convention. we need to change this to conform with the standard convention. for now, this change fixes the libtcc build.