### PR TITLE
fix release ci - apt stale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install libcurl
         run: |
+          sudo apt-get update -y
           sudo apt-get install -qy libcurl4-openssl-dev
       - name: compile
         run: |
@@ -84,6 +85,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install arm64 tools
         run: |
+          sudo apt-get update -y
           sudo apt-get install -qy binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: compile
         run: |


### PR DESCRIPTION
- fix for 0.0.11-pre release - ci breaks because apt needs updating