### PR TITLE
Docs: Fix prerequisite libraries for debian-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of fetch in the runtime) but, for now, you will need to install libcurl as
 follows.
 
 ```shell
-sudo apt install -y libcurl4-dev
+sudo apt install -y libcurl4-openssl-dev libssl-dev zlib1g-dev
 ```
 
 ### gcc/x64


### PR DESCRIPTION
Fixes `libcurl4-dev` name to be `libcurl4-openssl-dev` (actual package, with libcurl4-dev being its sub package). Adds libssl-dev and zlib1g-dev which are independent from libcurl.