### PR TITLE
fix for PATH on ./lo install

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -469,7 +469,7 @@ async function install (args = []) {
 to add ${AY}${dest_path}${AD} to your system path for this terminal
 session. run this export command:
 
-  export PATH=${dest_path}:$PATH
+  export PATH="${dest_path}:$PATH"
 
 to add it permanently edit your shell config and add the export.
   `)


### PR DESCRIPTION
Ran the ./lo install command and the print output to terminal is missing quotes around the export PATH.